### PR TITLE
uhc-util.cabal: allow hashable-1.2

### DIFF
--- a/uhc-util.cabal
+++ b/uhc-util.cabal
@@ -22,7 +22,7 @@ library
     base >= 4 && < 5,
     mtl >= 2 && < 3,
     fgl >= 5.4 && < 6.0,
-    hashable >= 1.1 && < 1.2,
+    hashable >= 1.1 && < 1.3,
     containers >= 0.4 && < 0.6,
     directory >= 1.1 && < 2,
     array >= 0.3 && < 0.5,


### PR DESCRIPTION
Signed-off-by: Sergei Trofimovich slyfox@gentoo.org
