### PR TITLE
GHC 9.0.1 support

### DIFF
--- a/src/UHC/Util/FPath.hs
+++ b/src/UHC/Util/FPath.hs
@@ -470,6 +470,4 @@ searchPathForReadableFile paths suffs fp
 -------------------------------------------------------------------------------------------
 
 fpathGetModificationTime :: FPath -> IO UTCTime
-fpathGetModificationTime fp = do let fn = fpathToStr fp
-                                 t <- getModificationTime fn
-                                 return (toUTCTime t)
+fpathGetModificationTime fp = getModificationTime (fpathToStr fp)

--- a/src/UHC/Util/RLList.hs
+++ b/src/UHC/Util/RLList.hs
@@ -23,7 +23,7 @@ import           Prelude hiding (length, init, null, concat)
 import qualified Prelude as P
 import           Data.Maybe
 import qualified Data.List as L
-import           Data.List hiding (concat, init, null, isPrefixOf, length, inits)
+import           Data.List hiding (concat, init, null, isPrefixOf, length, inits, singleton)
 import           Control.Monad
 import           UHC.Util.Utils
 import           UHC.Util.Binary

--- a/uhc-util.cabal
+++ b/uhc-util.cabal
@@ -27,7 +27,7 @@ library
     fgl >= 5.6,
     hashable >= 1.2.4,
     containers >= 0.4,
-    directory >= 1.1,
+    directory >= 1.2,
     array >= 0.3,
     process >= 1.1,
     binary >= 0.5,


### PR DESCRIPTION
Since version 1.2 the `directory` package returns an `UTCTime` directly from its `getModificationTime` function.

And since base-4.14.0.0 the `Data.List` module also exports `singleton`.