### PR TITLE
Remove pqueue dependency

### DIFF
--- a/uhc-util.cabal
+++ b/uhc-util.cabal
@@ -37,7 +37,6 @@ library
     time >= 1.2,
     fclabels >= 2.0.3,
     logict-state >= 0.1.0.2,
-    pqueue >= 1.3.1,
     vector >= 0.11,
     chr-pretty >= 0.1.0.0,
     chr-parse >= 0.1.0.0,


### PR DESCRIPTION
No modules are imported from `pqueue` anymore. Remove the dependency.